### PR TITLE
fix: exit when boto3 cannot be imported

### DIFF
--- a/standalone/falcon_data_replicator.py
+++ b/standalone/falcon_data_replicator.py
@@ -30,6 +30,7 @@ try:
 except ImportError as err:
     print(err)
     print('The AWS boto3 library is required to run Falcon Data Replicator.\nPlease execute "pip3 install boto3"')
+    sys.exit(1)
 
 
 # Class to hold our connector config and to track our running status


### PR DESCRIPTION
If you forget to install `boto3` (like me 🙈), the script will continue to execute. This PR just makes the experience a bit nicer 😄 

```
No module named 'boto3'
The AWS boto3 library is required to run Falcon Data Replicator.
Please execute "pip3 install boto3"
2022-09-27 15:06:05,521 FDR Connector INFO  _____ ____  ____        _
2022-09-27 15:06:05,521 FDR Connector INFO |  ___|  _ \|  _ \      (.\
2022-09-27 15:06:05,521 FDR Connector INFO | |_  | | | | |_) |     |/(\
2022-09-27 15:06:05,521 FDR Connector INFO |  _| | |_| |  _ <       \(\\
2022-09-27 15:06:05,521 FDR Connector INFO |_|   |____/|_| \_\      "^"`\
2022-09-27 15:06:05,521 FDR Connector INFO Process starting up
Traceback (most recent call last):
  File "CrowdStrike/FDR/standalone/falcon_data_replicator.py", line 288, in <module>
    sqs = boto3.resource('sqs',
NameError: name 'boto3' is not defined. Did you mean: 'bool'?
```