### PR TITLE
check if btyearray is not None before yield

### DIFF
--- a/ocsf/ocsf.py
+++ b/ocsf/ocsf.py
@@ -111,7 +111,11 @@ def read_fdr_part(rdr):
     tmp = bytearray()
     for char in rdr.read():
         if char == NEWLINE:
-            yield json.loads(tmp.decode('utf-8'))
+            if tmp:
+                try:
+                    yield json.loads(tmp.decode('utf-8'))
+                except json.JSONDecodeError as e:
+                    print(f"Error decoding JSON: {e}")
             tmp.clear()
         else:
             tmp.append(char)


### PR DESCRIPTION
Fix for the below issue
```bash
Traceback (most recent call last):
File "/home/fdr/FDR/falcon_data_replicator.py", line 503, in <module>
consume_data_replicator(s3_target, s3_cs, logger)
File "/home/fdr/FDR/falcon_data_replicator.py", line 270, in consume_data_replicator
res = fut.result()
File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 439, in result
return self.__get_result()
File "/usr/lib64/python3.9/concurrent/futures/_base.py", line 391, in __get_result
raise self._exception
File "/usr/lib64/python3.9/concurrent/futures/thread.py", line 58, in run
result = self.fn(*self.args, **self.kwargs)
File "/home/fdr/FDR/falcon_data_replicator.py", line 221, in process_queue_message
metrics = download_message_files(body, s3b, s3o, log_util)
File "/home/fdr/FDR/falcon_data_replicator.py", line 190, in download_message_files
result = handle_file(None, s3_path, s3ta, stream, log)
File "/home/fdr/FDR/falcon_data_replicator.py", line 123, in handle_file
total_events_in_file = transform_fdr_data_to_ocsf_data(
File "/home/fdr/FDR/ocsf/ocsf.py", line 139, in transform_fdr_data_to_ocsf_data
for event in read_fdr_part(chunk):
File "/home/fdr/FDR/ocsf/ocsf.py", line 114, in read_fdr_part
yield json.loads(tmp.decode('utf-8'))
File "/usr/lib64/python3.9/json/__init__.py", line 346, in loads
return _default_decoder.decode(s)
File "/usr/lib64/python3.9/json/decoder.py", line 337, in decode
obj, end = self.raw_decode(s, idx=_w(s, 0).end())
File "/usr/lib64/python3.9/json/decoder.py", line 355, in raw_decode
raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```