### PR TITLE
handle fdr partitioned feeds

### DIFF
--- a/falcon_data_replicator.py
+++ b/falcon_data_replicator.py
@@ -163,6 +163,9 @@ def download_message_files(msg, s3ta, s3or, log: logging.Logger):
         if not FDR.in_memory_transfer_only:
             # Create a local path name for our destination file based off of the S3 path
             local_path = os.path.join(FDR.output_path, s3_path)
+            if not os.path.exists(os.path.dirname(local_path)):
+                # Handle fdr platform and time partitioned folders
+                os.makedirs(os.path.dirname(local_path))
             start_download_time = time.time()
             # Open our local file for binary write
             with open(local_path, 'wb') as data:

--- a/falcon_data_replicator.py
+++ b/falcon_data_replicator.py
@@ -53,6 +53,9 @@ except ImportError as err:
                      "Data Replicator.\nPlease execute 'pip3 install boto3'"
                      ) from err
 
+# Global FDR
+FDR = None
+
 
 # This method is used as an exit handler. When a quit, cancel or interrupt is received,
 # this method forces FDR to finish processing the file it is working on before exiting.


### PR DESCRIPTION
when platform or timestamp partitions are enabled on a FDR feed it adds additional folder paths. This change ensures those folder paths exist.